### PR TITLE
Revert "Respawn rewrite"

### DIFF
--- a/addons/admin_menu/XEH_postInitClient.sqf
+++ b/addons/admin_menu/XEH_postInitClient.sqf
@@ -8,15 +8,14 @@ player setVariable [QGVAR(respawnTime), 99999, true];
 
 [{
     if !(alive player)then{
-        private _respawnTime = GETMVAR(EGVAR(respawn,playerRespawnTime),EGVAR(respawn,respawnTime));
-        SETPVAR(player,GVAR(respawnTime),_respawnTime);
+        player setVariable [QGVAR(respawnTime), playerRespawnTime, true];
     };
-}, 1, []] call CBA_fnc_addPerFrameHandler;
+}, 0, []] call CBA_fnc_addPerFrameHandler;
 
 if GVAR(AM_Enable) then{
     ["ace_spectatorSet", {
         params ["_isSpectator", "_player"];
-        if (_isSpectator and ((call BIS_fnc_admin != 0) or (GVAR(AM_Admin_UID) find (getPlayerUID player) != -1) or (isServer))) then {
+        if (_isSpectator and ((call BIS_fnc_admin != 0) or (GVAR(AM_Admin_UID) find (getPlayerUID player) != -1))) then {
             [{!isNull findDisplay 60000}, {
                 findDisplay 60000 ctrlCreate [QGVAR(aceSpectator_button_openMenu), 312206];
             }, []] call CBA_fnc_waitUntilAndExecute;

--- a/addons/admin_menu/functions/fnc_medVicStatus.sqf
+++ b/addons/admin_menu/functions/fnc_medVicStatus.sqf
@@ -9,11 +9,7 @@ _handle = [
         [_this select 1] call CBA_fnc_removePerFrameHandler;
     };
     lbClear (_control # 0);
-    {
-        if !(_x isEqualTo 0) then {
-            private _index = (_control # 0) lbAdd str(_x);
-            private _status = ["0", "X"] select (_x getVariable [QEGVAR(respawn,deployed), false]);
-            (_control # 0) lbSetTextRight  [_index, _status];
-        };
-    } forEach EGVAR(respawn,medVic_Server);
+    private _index = (_control # 0) lbAdd "MEDVIC";
+    private _status = ["0", "X"] select (missionNamespace getVariable [QEGVAR(respawn,deployed), false]);
+    (_control # 0) lbSetTextRight  [_index, _status];
 },1,[_control]] call CBA_fnc_addPerFrameHandler;

--- a/addons/admin_menu/functions/fnc_openMenu.sqf
+++ b/addons/admin_menu/functions/fnc_openMenu.sqf
@@ -2,7 +2,7 @@
 
 params ["_menu"];
 if (isMultiplayer) then {
-    if ((call BIS_fnc_admin != 0) or (GVAR(AM_Admin_UID) find (getPlayerUID player) != -1) or (isServer)) then{
+    if ((call BIS_fnc_admin != 0) or (GVAR(AM_Admin_UID) find (getPlayerUID player) != -1)) then{
         private _display = uiNamespace getVariable QGVAR(currentDisplay);
         if (!isNil "_display") then {
             _display closeDisplay 1;

--- a/addons/admin_menu/functions/fnc_setRespawnTime.sqf
+++ b/addons/admin_menu/functions/fnc_setRespawnTime.sqf
@@ -9,30 +9,15 @@ if (!isNil "_editIdc") then {
     _time = parseNumber(([(ctrlParent (_btnControl # 0)), _editIdc] call FUNC(getEditData)) # 1);
 };
 
-if (GETMVAR(EGVAR(respawn,customRespawnActive),false)) then {
-    if (count _id == 0) then{
-        [missionNamespace,[QEGVAR(respawn,playerRespawnTime),_time]] remoteExecCall ["setVariable", 0];
+if (count _id == 0) then{
+    [_time] remoteExecCall ["setPlayerRespawnTime", 0];
 
-        [format ["Set Everyones Respawn Time To %1", _time], 2] call FUNC(clientLog);
-        [format ["%1 Set Everyones Respawn Time To %2", name player, _time], 2, true] call FUNC(log);
-    }else{
-        private _unit = _id call BIS_fnc_objectFromNetId;
-        [missionNamespace,[QEGVAR(respawn,playerRespawnTime),_time]] remoteExecCall ["setVariable", _unit];
+    [format ["Set Everyones Respawn Time To %1", _time], 2] call FUNC(clientLog);
+    [format ["%1 Set Everyones Respawn Time To %2", name player, _time], 2, true] call FUNC(log);
+}else{
+    private _unit = _id call BIS_fnc_objectFromNetId;
+    [_time] remoteExecCall ["setPlayerRespawnTime", _unit];
 
-        [format ["%1 Set Respawn Time To %2", (name _unit), _time], 2] call FUNC(clientLog);
-        [format ["%1 Set %2 Respawn Time To %3", name player, (name _unit), _time], 2, true] call FUNC(log);
-    };
-} else {
-    if (count _id == 0) then{
-        [_time] remoteExecCall ["setPlayerRespawnTime", 0];
-
-        [format ["Set Everyones Respawn Time To %1", _time], 2] call FUNC(clientLog);
-        [format ["%1 Set Everyones Respawn Time To %2", name player, _time], 2, true] call FUNC(log);
-    }else{
-        private _unit = _id call BIS_fnc_objectFromNetId;
-        [_time] remoteExecCall ["setPlayerRespawnTime", _unit];
-
-        [format ["%1 Set Respawn Time To %2", (name _unit), _time], 2] call FUNC(clientLog);
-        [format ["%1 Set %2 Respawn Time To %3", name player, (name _unit), _time], 2, true] call FUNC(log);
-    };
+    [format ["%1 Set Respawn Time To %2", (name _unit), _time], 2] call FUNC(clientLog);
+    [format ["%1 Set %2 Respawn Time To %3", name player, (name _unit), _time], 2, true] call FUNC(log);
 };

--- a/addons/admin_menu/functions/fnc_toggleMedVic.sqf
+++ b/addons/admin_menu/functions/fnc_toggleMedVic.sqf
@@ -1,15 +1,8 @@
 #include "script_component.hpp"
 
-params ["_btnControl","_listboxIdc"];
+params ["_btnControl"];
 
-private _listboxControl = (ctrlParent _btnControl) displayCtrl _listboxIdc;
-private _vic = call compile (_listboxControl lbText (lbCurSel _listboxControl));
-
-if (isNil {_vic}) exitWith {
-    ["No valid medVic selected to deploy", 2] call FUNC(clientLog);
+if !(missionNamespace getVariable [QEGVAR(respawn,deployed), false]) exitWith {
+    missionNamespace setVariable [QEGVAR(respawn,deployed), true, true];
 };
-
-[_vic,[0,1] select GETVAR(_vic,EGVAR(respawn,deployed),false)] call EFUNC(respawn,vehicleDeploy);
-
-[format ["Toggled deployment for %1", _vic], 2] call FUNC(clientLog);
-[format ["%1 Toggled %2 deployment", name player, _vic], 2, true] call FUNC(log);
+missionNamespace setVariable [QEGVAR(respawn,deployed), false, true];

--- a/addons/admin_menu/ui/respawn.hpp
+++ b/addons/admin_menu/ui/respawn.hpp
@@ -12,9 +12,9 @@ $[
 [1400,"cav_admin_menu_respawn_edit_selected_respawnTime",[1,"",["0.610125 * safezoneW + safezoneX","0.490598 * safezoneH + safezoneY","0.0704798 * safezoneW","0.0376059 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
 [1611,"cav_admin_menu_respawn_button_selected_forceDeploy",[1,"Force Deploy",["0.610125 * safezoneW + safezoneX","0.547007 * safezoneH + safezoneY","0.0704798 * safezoneW","0.0376059 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
 [1610,"cav_admin_menu_respawn_button_selected_forceRespawn",[1,"Force Respawn",["0.610125 * safezoneW + safezoneX","0.603416 * safezoneH + safezoneY","0.0704798 * safezoneW","0.0376059 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
-[1802,"cav_admin_menu_respawn_frame_debug",[1,"Debug",["0.381065 * safezoneW + safezoneX","0.654 * safezoneH + safezoneY","0.308349 * safezoneW","0.088 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
-[1501,"cav_admin_menu_respawn_listbox_debug_vars",[1,"",["0.38547 * safezoneW + safezoneX","0.665 * safezoneH + safezoneY","0.215844 * safezoneW","0.066 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
-[1616,"cav_admin_menu_respawn_button_debug_deployMedVic",[1,"Deploy MedVic",["0.610125 * safezoneW + safezoneX","0.676 * safezoneH + safezoneY","0.0704798 * safezoneW","0.0376059 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]]
+[1802,"cav_admin_menu_respawn_frame_debug",[1,"Debug",["0.381065 * safezoneW + safezoneX","0.678628 * safezoneH + safezoneY","0.308349 * safezoneW","0.0658103 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
+[1501,"cav_admin_menu_respawn_listbox_debug_vars",[1,"",["0.38547 * safezoneW + safezoneX","0.697431 * safezoneH + safezoneY","0.215844 * safezoneW","0.0376059 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]],
+[1616,"cav_admin_menu_respawn_button_debug_deployMedVic",[1,"Deploy MedVic",["0.610125 * safezoneW + safezoneX","0.697431 * safezoneH + safezoneY","0.0704798 * safezoneW","0.0376059 * safezoneH"],[-1,-1,-1,-1],[-1,-1,-1,-1],[-1,-1,-1,-1],"","-1"],[]]
 ]
 */
 
@@ -155,17 +155,17 @@ class GVAR(respawn):GVAR(main)
     	idc = 1802;
     	text = "Debug"; //--- ToDo: Localize;
     	x = 0.381065 * safezoneW + safezoneX;
-    	y = 0.654 * safezoneH + safezoneY;
+    	y = 0.678628 * safezoneH + safezoneY;
     	w = 0.308349 * safezoneW;
-    	h = 0.088 * safezoneH;
+    	h = 0.0658103 * safezoneH;
     };
     class GVAR(respawn_listbox_debug_vars): RscListbox
     {
     	idc = 1501;
     	x = 0.38547 * safezoneW + safezoneX;
-    	y = 0.665 * safezoneH + safezoneY;
+    	y = 0.697431 * safezoneH + safezoneY;
     	w = 0.215844 * safezoneW;
-    	h = 0.066 * safezoneH;
+    	h = 0.0376059 * safezoneH;
         onLoad = QUOTE([ARR_1(_this)] call FUNC(medVicStatus););
     };
     class GVAR(respawn_button_debug_deployMedVic): RscButton
@@ -173,9 +173,9 @@ class GVAR(respawn):GVAR(main)
     	idc = 1616;
     	text = "Deploy MedVic"; //--- ToDo: Localize;
     	x = 0.610125 * safezoneW + safezoneX;
-    	y = 0.676 * safezoneH + safezoneY;
+    	y = 0.697431 * safezoneH + safezoneY;
     	w = 0.0704798 * safezoneW;
     	h = 0.0376059 * safezoneH;
-        onButtonClick = QUOTE([ARR_2(_this # 0,1501)] call FUNC(toggleMedVic););
+        onButtonClick = QUOTE([ARR_1(_this)] call FUNC(toggleMedVic););
     };
 };

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 0
 #define MINOR 9
-#define PATCHLVL 4
+#define PATCHLVL 3
 #define BUILD 0

--- a/addons/respawn/XEH_PREP.hpp
+++ b/addons/respawn/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addPlayerToQueue);
 PREP(allDead);
 PREP(isMedVicDeployed);
 PREP(medDeploy);
@@ -5,4 +6,6 @@ PREP(medVicDamage);
 PREP(OnKilled);
 PREP(OnRespawn);
 PREP(playerTicketsLeft);
+PREP(popQueue);
+PREP(removePlayerQueue);
 PREP(vehicleDeploy);

--- a/addons/respawn/XEH_postInitClient.sqf
+++ b/addons/respawn/XEH_postInitClient.sqf
@@ -5,30 +5,24 @@ if (!hasInterface) exitWith {};
 
 LOG(MSG_INIT);
 
-setPlayerRespawnTime 99999;
-[{time>0},{setPlayerRespawnTime 99999;},[]] call CBA_fnc_waitUntilAndExecute;
+
+setPlayerRespawnTime GVAR(RespawnTime);
+
 
 if (GVAR(CustomRespawnMode) != 3) then {
     [[player, GVAR(NumberOfRespawns)] call BIS_fnc_respawnTickets] call BIS_fnc_MP;
+    setPlayerRespawnTime GVAR(RespawnTime);
 };
-[{time>0},{
-    if (GVAR(CustomRespawnMode) == 1 || GVAR(CustomRespawnMode) == 2) then {
-        _medVic = call compile format["%1_%2",GVAR(medVicString),(call ace_common_fnc_playerSide)];
-        if (isNil {_medVic}) then {
-            _medVicgen = call (compile GVAR(medVicString));
-            if (isNil {_medVicgen}) then {
-                systemchat localize LSTRING(medVic_errorMessage);
-                diag_log "No medvic found";
-            } else {
-                GVAR(medVic) = _medVicgen;
-                diag_log "Setting Gen Medvic";
-            };
-        } else {
-            GVAR(medVic) = _medVic;
-            diag_log "Setting Side MedVic";
-        };
-        if (GVAR(CustomRespawnMode) == 1) then {
-            call FUNC(medDeploy);
-        };
+
+if (GVAR(CustomRespawnMode) == 1 || GVAR(CustomRespawnMode) == 2) then {
+    _medVic = call (compile GVAR(medVicString));
+    //systemChat str(_medvic);
+    if (isNull _medVic) then {
+        systemchat localize LSTRING(medVic_errorMessage);
+    } else {
+        GVAR(medVic) = _medVic;
     };
-},[]] call CBA_fnc_waitUntilAndExecute;
+    if (GVAR(CustomRespawnMode) == 1) then {
+        call FUNC(medDeploy);
+    };
+};

--- a/addons/respawn/XEH_postInitServer.sqf
+++ b/addons/respawn/XEH_postInitServer.sqf
@@ -3,27 +3,25 @@
 LOG(MSG_INIT);
 
 if (GVAR(CustomRespawnMode) == 1 || GVAR(CustomRespawnMode) == 2) then {
-    GVAR(medVic_Server) = [];
-    private _medVicgen = call (compile GVAR(medVicString));
-    if (isNil {_medVicgen}) then {
-        GVAR(medVic_Server) pushBack 0;
+    _medVic = call (compile GVAR(medVicString));
+    if (isNull _medVic) then {
+        systemchat localize LSTRING(medVic_errorMessage);
     } else {
-        GVAR(medVic_Server) pushBack _medVicgen;
+        GVAR(medVic) = _medVic;
     };
-    {
-        private _medvic = call compile format["%1_%2",GVAR(medVicString),_x];
-        if (isNil {_medVic}) then {
-            GVAR(medVic_Server) pushBack 0;
-        } else {
-            GVAR(medVic_Server) pushBack _medVic;
-        };
-    } forEach [west,east,independent];
     if (GVAR(CustomRespawnMode) == 1) then {
-        {
-            if !(_x isEqualTo 0) then {
-                _x setVariable [QGVAR(deployed),false,true];
-            };
-        } forEach GVAR(medVic_Server);
+        missionNamespace setVariable [QGVAR(deployed),false,true];
     };
-    publicVariable QGVAR(medVic_Server);
+};
+
+if (GVAR(CustomRespawnMode) == 1) then{
+    /* SETMPVAR(GVAR(deathQueue), []); */
+    CAV_DQ = [];
+    publicVariable "CAV_DQ";
+
+    addMissionEventHandler ["HandleDisconnect", {
+    	params ["_unit", "_id", "_uid", "_name"];
+        _unit call FUNC(removePlayerQueue);
+    	false
+    }];
 };

--- a/addons/respawn/functions/fnc_addPlayerToQueue.sqf
+++ b/addons/respawn/functions/fnc_addPlayerToQueue.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+params ["_player"];
+
+CAV_DQ pushBack _player;
+publicVariable "CAV_DQ";
+true

--- a/addons/respawn/functions/fnc_medDeploy.sqf
+++ b/addons/respawn/functions/fnc_medDeploy.sqf
@@ -15,11 +15,12 @@ Description:
     "Deploy",																									// Title of the action
     "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa",	// Idle icon shown on screen
     "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_reviveMedic_ca.paa",	// Progress icon shown on screen
-    format["(((objectParent player) == %1) and !(%1 getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to be shown
-    format["(((objectParent player) == %1) and !(%1 getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to progress
+    format["(((objectParent player) == %1) and !(missionNamespace getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to be shown
+    format["(((objectParent player) == %1) and !(missionNamespace getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to progress
     {},																											// Code executed when action starts
     {},																											// Code executed on every progress tick
     {
+    missionNamespace setVariable [QGVAR(deployed), true, true];
     [GVAR(medVic), 0] call FUNC(vehicleDeploy);
     /* [GVAR(medVic), "", 1] remoteExec [QFUNC(vehicleDeploy), 0]; */
     },																											// Code executed on completion
@@ -36,11 +37,12 @@ Description:
     "Undeploy",																									// Title of the action
     "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_reviveMedic_ca.paa",	// Idle icon shown on screen
     "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_revive_ca.paa",	// Progress icon shown on screen
-    format["(((objectParent player) == %1) and (%1 getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to be shown
-    format["(((objectParent player) == %1) and (%1 getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to progress
+    format["(((objectParent player) == %1) and (missionNamespace getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to be shown
+    format["(((objectParent player) == %1) and (missionNamespace getVariable ['%2', false]) and (getDammage %1 != 1))", GVAR(medVic), QGVAR(deployed)],		// Condition for the action to progress
     {},																											// Code executed when action starts
     {},																											// Code executed on every progress tick
     {
+    missionNamespace setVariable [QGVAR(deployed), false, true];
     [GVAR(medVic), 1] call FUNC(vehicleDeploy);
     /* [GVAR(medVic), "", 0] remoteExec [QFUNC(vehicleDeploy), 0]; */
     },																											// Code executed on completion

--- a/addons/respawn/functions/fnc_onRespawn.sqf
+++ b/addons/respawn/functions/fnc_onRespawn.sqf
@@ -1,35 +1,14 @@
 #include "script_component.hpp"
-#define SPAWN_OFFSET 1.5
 
 switch (GVAR(CustomRespawnMode)) do
 {
     case 1 :
     {
-        GVAR(medVic) call {
-            private _unit = ACE_player;
-            if (isNull _this || !(_this isEqualType objNull)) exitWith {
-                false
-            };
-            if (player moveInAny _this) exitWith {
-                true
-            };
-            //Try to spawn next to the object
-            private _zPos = (ASLToAGL getPosASL _this) select 2;
-            private _bb = boundingBox _this;
-            private _moveDirectionSelect = speed _this < 0 && !(_this isKindOf "CAManBase");
-
-            private _offset = (getPos _this distance getPosVisual _this) + SPAWN_OFFSET;
-            private _spawnPos = (_this getRelPos [
-                (_bb select _moveDirectionSelect select 1)
-                +
-                ([-_offset, _offset] select _moveDirectionSelect), //avoid appearing in front of a moving vehicle
-                linearConversion [0, 100, round random 100, -15, 15]
-            ]) vectorAdd [0, 0, _zPos];
-            if (isNil "_spawnPos" || {_spawnPos isEqualTo [0,0,0]}) then {systemChat "spawn position is undefined"; false};
-            _unit setVehiclePosition [_spawnPos, [], 0, "NONE"];
-            _unit setDir (_unit getDir _this);
-            true
-        }
+        [{if (player moveInAny GVAR(medVic)) then{
+            [player] remoteExecCall [QFUNC(popQueue), 2];
+            [_this select 1] call CBA_fnc_removePerFrameHandler;
+        };
+        }, 1, []] call CBA_fnc_addPerFrameHandler;
     };
 
     case 2 :
@@ -38,9 +17,7 @@ switch (GVAR(CustomRespawnMode)) do
     };
 };
 
-if !(GVAR(CustomRespawnMode) == 3) then {
-    [player,-1,true] call BIS_fnc_respawnTickets;
-};
+[player,-1,true] call BIS_fnc_respawnTickets;
 if ([player,0,true] call BIS_fnc_respawnTickets == 1) then {
     "1 Respawn Remaining!" remoteExecCall ["systemChat", player];
 } else {
@@ -50,3 +27,13 @@ if ([player,0,true] call BIS_fnc_respawnTickets == 1) then {
 [false] call ace_spectator_fnc_setSpectator;
 
 setPlayerRespawnTime 99999;
+
+/* systemChat format ["Respawn Time Set:%1", playerRespawnTime];  */
+
+/* [{
+    systemChat format ["Respawn Time Set Player:%1", player];
+    setPlayerRespawnTime 99999;
+    if (playerRespawnTime > 9999) then{
+        [_this select 1] call CBA_fnc_removePerFrameHandler;
+    };
+}, 1, []] call CBA_fnc_addPerFrameHandler; */

--- a/addons/respawn/functions/fnc_popQueue.sqf
+++ b/addons/respawn/functions/fnc_popQueue.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+CAV_DQ deleteAt 0;
+publicVariable "CAV_DQ";
+true

--- a/addons/respawn/functions/fnc_removePlayerQueue.sqf
+++ b/addons/respawn/functions/fnc_removePlayerQueue.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+
+params ["_player"];
+
+if (_player in CAV_DQ) exitWith{
+    CAV_DQ deleteAt (CAV_DQ find _player);
+    publicVariable "CAV_DQ";
+    true
+};
+false

--- a/addons/respawn/functions/fnc_vehicleDeploy.sqf
+++ b/addons/respawn/functions/fnc_vehicleDeploy.sqf
@@ -5,13 +5,11 @@ params [["_vic", objNull], ["_mode", 0]];
 if !(isNull _vic) then{
     switch (_mode) do {
         case 0:{
-            SETPVAR(_vic,GVAR(deployed),true);
-            SETPVAR(_vic,deployedFuel,fuel _vic);
+            SETPVAR(_vic, deployedFuel, fuel _vic);
             _vic setFuel 0;
         };
         case 1:{
-            SETPVAR(_vic,GVAR(deployed),false);
-            _vic setFuel GETVAR(_vic,deployedFuel,0.75);
+            _vic setFuel GETVAR(_vic, deployedFuel, 0.75);
         };
     };
 };

--- a/addons/respawn/initSettings.sqf
+++ b/addons/respawn/initSettings.sqf
@@ -20,7 +20,7 @@
     true,
     {
         params ["_value"];
-        GVAR(NumberOfRespawns) = round _value;
+        GVAR(NumberOfRespawns) = _value;
     }
 ] call CBA_Settings_fnc_init;
 
@@ -33,7 +33,7 @@
     true,
     {
         params ["_value"];
-        GVAR(RespawnTime) = round _value;
+        GVAR(RespawnTime) = _value;
     }
 ] call CBA_Settings_fnc_init;
 
@@ -59,6 +59,6 @@
     true,
     {
         params ["_value"];
-        GVAR(medVicDeployTime) = round _value;
+        GVAR(medVicDeployTime) = _value;
     }
 ] call CBA_Settings_fnc_init;

--- a/tools/make.py
+++ b/tools/make.py
@@ -30,7 +30,7 @@
 
 ###############################################################################
 
-__version__ = "0.9.4"
+__version__ = "0.9.3"
 
 import sys
 
@@ -58,7 +58,7 @@ if sys.platform == "win32":
 
 ######## GLOBALS #########
 project = "@cav"
-project_version = "0.9.4"
+project_version = "0.9.2"
 arma3tools_path = ""
 work_drive = ""
 module_root = ""


### PR DESCRIPTION
Reverts Brecon1/5thCavMod#8

the moveInAny does not work for simultaneous respawn
this is why the queue system was added because moveInAny did not work last time

the moveInAny check if the player can move in
as there is currently room during the check it returns true
it then moves the player into the place
as there is another player doing the same thing
that playing moves into the slot
the current players tries to move into that slot
fails as that slot is filled
and due to the player already having spawned on his death pos
stays there
hence the death queue